### PR TITLE
Add Dolphin PV, PVC and deployment volume

### DIFF
--- a/manifests/syncthing/syncthing-deployment.yaml
+++ b/manifests/syncthing/syncthing-deployment.yaml
@@ -1,57 +1,62 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: syncthing
-    namespace: syncthing
+  name: syncthing
+  namespace: syncthing
 spec:
-    replicas: 1
-    selector:
-        matchLabels:
-            app: syncthing
-    template:
-        metadata:
-            labels:
-                app: syncthing
-        spec:
-            containers:
-                - name: syncthing
-                  image: syncthing/syncthing:1.29
-                  env:
-                      - name: TZ
-                        value: America/Toronto
-                  ports:
-                      - containerPort: 8384 # Web UI
-                      - containerPort: 22000 # Sync
-                      - containerPort: 21027 # Local discovery (UDP)
-                        protocol: UDP
-                  livenessProbe:
-                      httpGet:
-                          path: /
-                          port: 8384
-                      initialDelaySeconds: 10
-                      periodSeconds: 10
-                  readinessProbe:
-                      httpGet:
-                          path: /
-                          port: 8384
-                      initialDelaySeconds: 5
-                      periodSeconds: 5
-                  resources:
-                      requests:
-                          memory: "128Mi"
-                          cpu: "100m"
-                      limits:
-                          memory: "512Mi"
-                          cpu: "500m"
-                  volumeMounts:
-                      - name: saves
-                        mountPath: /data
-                      - name: config
-                        mountPath: /var/syncthing
-            volumes:
-                - name: saves
-                  persistentVolumeClaim:
-                      claimName: syncthing-pvc
-                - name: config
-                  persistentVolumeClaim:
-                      claimName: syncthing-config-pvc
+  replicas: 1
+  selector:
+    matchLabels:
+      app: syncthing
+  template:
+    metadata:
+      labels:
+        app: syncthing
+    spec:
+      containers:
+        - name: syncthing
+          image: syncthing/syncthing:1.29
+          env:
+            - name: TZ
+              value: America/Toronto
+          ports:
+            - containerPort: 8384 # Web UI
+            - containerPort: 22000 # Sync
+            - containerPort: 21027 # Local discovery (UDP)
+              protocol: UDP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8384
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8384
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: saves
+              mountPath: /data
+            - name: config
+              mountPath: /var/syncthing
+            - name: dolphin-saves
+              mountPath: /Dolphin
+      volumes:
+        - name: saves
+          persistentVolumeClaim:
+            claimName: syncthing-pvc
+        - name: config
+          persistentVolumeClaim:
+            claimName: syncthing-config-pvc
+        - name: dolphin-saves
+          persistentVolumeClaim:
+            claimName: syncthing-dolphin-pvc

--- a/manifests/syncthing/syncthing-dolphin-pv.yaml
+++ b/manifests/syncthing/syncthing-dolphin-pv.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: syncthing-dolphin-pv
+    name: syncthing-dolphin-pv
 
 spec:
-  capacity:
-    storage: 50Gi
-  accessModes:
-    - ReadWriteMany
-  hostPath:
-    path: /mnt/retrogaming/Dolphin
+    capacity:
+        storage: 50Gi
+    accessModes:
+        - ReadWriteMany
+    hostPath:
+        path: /mnt/retrogaming/Dolphin

--- a/manifests/syncthing/syncthing-dolphin-pv.yaml
+++ b/manifests/syncthing/syncthing-dolphin-pv.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: syncthing-dolphin-pv
+
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /mnt/retrogaming/Dolphin

--- a/manifests/syncthing/syncthing-dolphin-pvc.yaml
+++ b/manifests/syncthing/syncthing-dolphin-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing-dolphin-pvc
+  namespace: syncthing
+
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  volumeName: syncthing-dolphin-pv


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a 50Gi RWX Dolphin PV/PVC and mounts it at `/Dolphin` in the Syncthing deployment.
> 
> - **Kubernetes (Syncthing)**:
>   - **Deployment `manifests/syncthing/syncthing-deployment.yaml`**:
>     - Mounts new volume `dolphin-saves` at `/Dolphin`.
>     - Adds `dolphin-saves` volume backed by `PersistentVolumeClaim` `syncthing-dolphin-pvc`.
>   - **Storage**:
>     - Adds `PersistentVolume` `syncthing-dolphin-pv` (50Gi, `ReadWriteMany`, hostPath `/mnt/retrogaming/Dolphin`).
>     - Adds `PersistentVolumeClaim` `syncthing-dolphin-pvc` (50Gi, `ReadWriteMany`) bound to `syncthing-dolphin-pv`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eedd4807a45b4d6ee68554247e00cd439ca13a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->