### PR TITLE
Add Cemu persistent storage to Syncthing deployment

### DIFF
--- a/manifests/syncthing/syncthing-cemu-pv.yaml
+++ b/manifests/syncthing/syncthing-cemu-pv.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: syncthing-cemu-pv
+
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /mnt/retrogaming/Cemu

--- a/manifests/syncthing/syncthing-cemu-pvc.yaml
+++ b/manifests/syncthing/syncthing-cemu-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing-cemu-pvc
+  namespace: syncthing
+
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+  volumeName: syncthing-cemu-pv

--- a/manifests/syncthing/syncthing-deployment.yaml
+++ b/manifests/syncthing/syncthing-deployment.yaml
@@ -50,6 +50,8 @@ spec:
               mountPath: /var/syncthing
             - name: dolphin-saves
               mountPath: /Dolphin
+            - name: cemu-saves
+              mountPath: /Cemu
       volumes:
         - name: saves
           persistentVolumeClaim:
@@ -60,3 +62,6 @@ spec:
         - name: dolphin-saves
           persistentVolumeClaim:
             claimName: syncthing-dolphin-pvc
+        - name: cemu-saves
+          persistentVolumeClaim:
+            claimName: syncthing-cemu-pvc


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new Cemu persistent volume/claim and mounts it in the Syncthing deployment at `/Cemu`.
> 
> - **Kubernetes (Syncthing)**:
>   - **Storage**:
>     - Add `PersistentVolume` `syncthing-cemu-pv` in `manifests/syncthing/syncthing-cemu-pv.yaml` (20Gi `ReadWriteMany`, hostPath `/mnt/retrogaming/Cemu`).
>     - Add `PersistentVolumeClaim` `syncthing-cemu-pvc` in `manifests/syncthing/syncthing-cemu-pvc.yaml` (20Gi request, bound to `syncthing-cemu-pv`).
>   - **Deployment** (`manifests/syncthing/syncthing-deployment.yaml`):
>     - Mount new volume `cemu-saves` at `/Cemu` and add corresponding PVC reference `syncthing-cemu-pvc` in `volumes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86e8a5fd86a76a744a1556d2f8e160c51b314072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->