### PR TITLE
Add file mounts for Eden file sync

### DIFF
--- a/manifests/syncthing/syncthing-deployment.yaml
+++ b/manifests/syncthing/syncthing-deployment.yaml
@@ -52,6 +52,8 @@ spec:
               mountPath: /Dolphin
             - name: cemu-saves
               mountPath: /Cemu
+            - name: eden-saves
+              mountPath: /Eden
       volumes:
         - name: saves
           persistentVolumeClaim:
@@ -65,3 +67,6 @@ spec:
         - name: cemu-saves
           persistentVolumeClaim:
             claimName: syncthing-cemu-pvc
+        - name: eden-saves
+          persistentVolumeClaim:
+            claimName: syncthing-eden-pvc

--- a/manifests/syncthing/syncthing-eden-pv.yaml
+++ b/manifests/syncthing/syncthing-eden-pv.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: syncthing-eden-pv
+
+spec:
+  capacity:
+    storage: 25Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /mnt/retrogaming/Eden

--- a/manifests/syncthing/syncthing-eden-pvc.yaml
+++ b/manifests/syncthing/syncthing-eden-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing-eden-pvc
+  namespace: syncthing
+
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 25Gi
+  volumeName: syncthing-eden-pv


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an Eden saves volume to Syncthing via new PV/PVC and mounts it at `/Eden` in the deployment.
> 
> - **Kubernetes (Syncthing)**:
>   - **Deployment** (`manifests/syncthing/syncthing-deployment.yaml`):
>     - Add `eden-saves` volume mount at `/Eden`.
>     - Reference new PVC `syncthing-eden-pvc` in `eden-saves` volume.
>   - **Storage**:
>     - Add PV `syncthing-eden-pv` (`25Gi`, `ReadWriteMany`, `hostPath: /mnt/retrogaming/Eden`).
>     - Add PVC `syncthing-eden-pvc` (binds to `syncthing-eden-pv`, `25Gi`, `ReadWriteMany`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7415076509674de04d13b92b73e62e9c11c9b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->