### PR TITLE
Add abs-kosync-bridge for ABS and KOReader sync

### DIFF
--- a/apps/abs-kosync-bridge-app.yaml
+++ b/apps/abs-kosync-bridge-app.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: abs-kosync-bridge
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:nourez/klusty-krab-home-lab.git
+    targetRevision: HEAD
+    path: manifests/abs-kosync-bridge
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: abs-kosync-bridge
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true

--- a/manifests/abs-kosync-bridge/deployment.yaml
+++ b/manifests/abs-kosync-bridge/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: abs-kosync-bridge
+  namespace: abs-kosync-bridge
+  labels:
+    app: abs-kosync-bridge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: abs-kosync-bridge
+  template:
+    metadata:
+      labels:
+        app: abs-kosync-bridge
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: klusty-krab-node-1
+      containers:
+        - name: abs-kosync-bridge
+          image: ghcr.io/cporcellijr/abs-kosync-bridge:v6.7.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 5757
+          env:
+            - name: TZ
+              value: America/Toronto
+            - name: LOG_LEVEL
+              value: INFO
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: books
+              mountPath: /books
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: abs-kosync-bridge-data
+        - name: books
+          hostPath:
+            path: /mnt/media/Books
+            type: Directory

--- a/manifests/abs-kosync-bridge/ingress.yaml
+++ b/manifests/abs-kosync-bridge/ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: abs-kosync-bridge
+  namespace: abs-kosync-bridge
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`abs-kosync.home`)
+      kind: Rule
+      services:
+        - name: abs-kosync-bridge
+          port: 80

--- a/manifests/abs-kosync-bridge/namespace.yaml
+++ b/manifests/abs-kosync-bridge/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: abs-kosync-bridge

--- a/manifests/abs-kosync-bridge/pvc.yaml
+++ b/manifests/abs-kosync-bridge/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: abs-kosync-bridge-data
+  namespace: abs-kosync-bridge
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/manifests/abs-kosync-bridge/service.yaml
+++ b/manifests/abs-kosync-bridge/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: abs-kosync-bridge
+  namespace: abs-kosync-bridge
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 10.0.0.237
+  selector:
+    app: abs-kosync-bridge
+  ports:
+    - name: http
+      port: 80
+      targetPort: 5757


### PR DESCRIPTION
## Summary

- Add Argo CD application `abs-kosync-bridge` (picked up by `root-app`).
- Deploy manifests: Deployment (v6.7.0), Longhorn PVC for `/data`, hostPath `/mnt/media/Books` at `/books`, MetalLB `10.0.0.237`, Traefik route `abs-kosync.home`.
- Pin workload to `klusty-krab-node-1` until storage moves to NAS.

## Post-merge setup

1. Open http://abs-kosync.home or http://10.0.0.237
2. In Settings, connect Audiobookshelf (`http://audiobookshelf.audiobookshelf`) and Grimmory (`http://grimmory.grimmory`)
3. Enable KOSync with **Target URL** pointing at Grimmory's KOSync server (same as KOReader devices)
4. Create book mappings via Suggestions or Add Book

## Test plan

- [ ] Argo CD syncs `abs-kosync-bridge` application healthy
- [ ] Pod schedules on `klusty-krab-node-1` and reaches Ready
- [ ] Web UI loads at `abs-kosync.home` / `10.0.0.237`
- [ ] Settings Test succeeds for ABS and Grimmory
- [ ] One mapped title syncs progress ABS ↔ KOReader via Grimmory KOSync


Made with [Cursor](https://cursor.com)